### PR TITLE
deployment errors if all config isn't provided at deploy time

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2023 pguimaraes
+   Copyright 2024 Canonical Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/config.yaml
+++ b/config.yaml
@@ -18,7 +18,7 @@ options:
     default: ""
     type: string
     description: |
-      LicenseKey should be a file, appiled as a bas64 string
+      LicenseKey should be a file, applied as a bas64 string
 
       file format:
           kind: LicenseKey
@@ -27,7 +27,8 @@ options:
             certificate: <content>
             token: <content>
 
-      $ juju config calico-enterprise license="$(cat license | base64 -w0)"
+      example use:
+      juju config calico-enterprise license="$(cat license | base64 -w0)"
   addons:
     default: False
     type: boolean
@@ -66,7 +67,10 @@ options:
     default: ""
     type: string
     description: |
-      String in the format of "user:password" run through base64 encoding
+      Credentials in the format <user>:<password>, applied as a bas64 string
+
+      example use:
+      juju config calico-enterprise image_registry_secret="$(echo user:password | base64 -w0)"
   tigera_version:
     default: 'distro'
     type: string
@@ -119,10 +123,9 @@ options:
     description: |
       If set, BGP will be configured in the early stage (pre-k8s) and passed on to k8s. 
       If the configuration is unset or has a string len=0, then bgp_parameters is considered
-      empty. This option can be configured as follows:
-        $ juju config tigera bgp_parameters="$(cat bgp_params.yaml)"
+      empty.
 
-      For example:
+      file format:
       - hostname: <hostname>
         asn: <number>
         stableAddress: <IP>
@@ -136,3 +139,5 @@ options:
           peerASN: <2>
         - ...
 
+      example use:
+      juju config calico-enterprise bgp_parameters="$(cat bgp_params.yaml)"

--- a/config.yaml
+++ b/config.yaml
@@ -67,7 +67,7 @@ options:
     default: ""
     type: string
     description: |
-      Credentials in the format <user>:<password>, applied as a bas64 string
+      Credentials in the format <user>:<password>, applied as a base64 string
 
       example use:
       juju config calico-enterprise image_registry_secret="$(echo user:password | base64 -w0)"

--- a/config.yaml
+++ b/config.yaml
@@ -18,7 +18,7 @@ options:
     default: ""
     type: string
     description: |
-      LicenseKey should be a file, applied as a bas64 string
+      LicenseKey should be a file, applied as a base64 string
 
       file format:
           kind: LicenseKey

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,9 @@ target-version = ["py38"]
 # Linting tools configuration
 [tool.ruff]
 line-length = 99
-select = ["E", "W", "F", "C", "N", "D", "I001"]
+extend-exclude = ["__pycache__", "*.egg_info"]
+
+[tool.ruff.lint]
 extend-ignore = [
     "D203",
     "D204",
@@ -32,8 +34,8 @@ extend-ignore = [
     "D413",
 ]
 ignore = ["E501", "D107"]
-extend-exclude = ["__pycache__", "*.egg_info"]
 per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
+select = ["E", "W", "F", "C", "N", "D", "I001"]
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 10

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ ops >= 1.5.0
 git+https://github.com/charmed-kubernetes/conctl#egg=conctl
 Jinja2 < 3.1
 pydantic <=1.9.0 # Python 3.6 support requires <= 1.9.0
+tenacity

--- a/src/charm.py
+++ b/src/charm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2023 pguimaraes
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 #
 # Learn more at: https://juju.is/docs/sdk

--- a/src/peer.py
+++ b/src/peer.py
@@ -40,7 +40,7 @@ def _localhost_ips() -> List[ip_address]:
 
 
 class BGPPeer(BaseModel):
-    """Represents a host interface's bpg peer info."""
+    """Represents a host interface's bgp peer info."""
 
     ip: str = Field(alias="peerIP")
     asn: int = Field(alias="peerASNumber")
@@ -61,7 +61,7 @@ class BGPPeerBinding(BaseModel):
 
 
 class BGPLabels(BaseModel):
-    """Represents a host's bpg label info."""
+    """Represents a host's bgp label info."""
 
     rack: str
 
@@ -74,7 +74,7 @@ class StableAddress(BaseModel):
 
 
 class BGPParameters(BaseModel):
-    """Represents a host's bpg label info."""
+    """Represents a host's bgp label info."""
 
     as_number: int = Field(alias="asNumber")
     interface_addresses: List[str] = Field(alias="interfaceAddresses")
@@ -160,7 +160,7 @@ class CalicoEnterprisePeer(Object):
         self.framework.observe(events.relation_joined, self.peer_change)
         self.framework.observe(events.relation_changed, self.peer_change)
 
-    def pubilsh_bgp_parameters(self):
+    def publish_bgp_parameters(self):
         """Publish bgp parameters to peer relation."""
         if bgp_parameters := _early_service_cfg():
             for relation in self.model.relations[self.endpoint]:
@@ -171,7 +171,7 @@ class CalicoEnterprisePeer(Object):
         """Respond to any changes in the peer data."""
         if len(self._computed_bgp_layout(local_only=True).nodes) == 0:
             log.info(f"Sharing bgp params from {self.model.unit.name}")
-            self.pubilsh_bgp_parameters()
+            self.publish_bgp_parameters()
         self.on.bgp_parameters_changed.emit()
 
     def quorum_data(self, key: str) -> Optional[str]:

--- a/tests/integration/setup.sh
+++ b/tests/integration/setup.sh
@@ -144,7 +144,7 @@ function juju_create_manual_model() {
         juju bootstrap manual-cloud
     fi
 
-    juju add-model ${JUJU_MODEL} --config="${MODEL_CONFIG}"
+    juju add-model ${JUJU_MODEL} --config="${MODEL_CONFIG}" --config logging-config='<root>=DEBUG' --config automatically-retry-hooks=false
     juju add-space bgp
     juju add-space mgmt
     juju add-space tor-network

--- a/tests/integration/test_calico_enterprise.py
+++ b/tests/integration/test_calico_enterprise.py
@@ -41,7 +41,7 @@ async def test_build_and_deploy(
         charm = await ops_test.build_charm(".")
 
     overlays = [
-        ops_test.Bundle("kubernetes-core", channel="edge"),
+        ops_test.Bundle("kubernetes-core", channel="stable"),
         Path("tests/data/charm.yaml"),
     ]
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,4 +1,4 @@
-# Copyright 2023 pguimaraes
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 #
 # Learn more about testing at: https://juju.is/docs/sdk/testing

--- a/tests/unit/test_peer.py
+++ b/tests/unit/test_peer.py
@@ -159,7 +159,7 @@ def test_publish_bgp_parameters_no_service(harness, charm):
     harness.disable_hooks()
     with mock.patch("peer.CALICO_EARLY_SERVICE") as patched:
         patched.exists.return_value = False
-        charm.peers.pubilsh_bgp_parameters()
+        charm.peers.publish_bgp_parameters()
 
     for relation in charm.model.relations["calico-enterprise"]:
         assert relation.data[charm.model.unit].get("bgp-parameters") is None
@@ -178,7 +178,7 @@ def test_publish_bgp_parameters_invalid_calico_early(early_service, harness, cha
     elif failure == "Invalid Config":
         early_service.side_effect = ["CALICO_EARLY_NETWORKING=magic.yaml", "invalid"]
 
-    charm.peers.pubilsh_bgp_parameters()
+    charm.peers.publish_bgp_parameters()
     for relation in charm.model.relations["calico-enterprise"]:
         assert relation.data[charm.model.unit].get("bgp-parameters") is None
 
@@ -187,7 +187,7 @@ def test_publish_bgp_parameters_json_passthru(harness, charm):
     harness.disable_hooks()
     with mock.patch("peer._early_service_cfg") as patched:
         expected = patched.return_value.json.return_value = "expected"
-        charm.peers.pubilsh_bgp_parameters()
+        charm.peers.publish_bgp_parameters()
 
     for relation in charm.model.relations["calico-enterprise"]:
         assert relation.data[charm.model.unit]["bgp-parameters"] == expected

--- a/tests/unit/test_peer.py
+++ b/tests/unit/test_peer.py
@@ -1,4 +1,4 @@
-# Copyright 2023 pguimaraes
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 #
 # Learn more about testing at: https://juju.is/docs/sdk/testing

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,3 @@
-# Copyright 2023 pguimaraes
-# See LICENSE file for licensing details.
-
 [tox]
 skipsdist=True
 skip_missing_interpreters = True
@@ -31,26 +28,19 @@ deps =
     black
     ruff
 commands =
-    black {[vars]all_path}
-    ruff --fix {[vars]all_path}
+    black -l 99 {[vars]all_path}
+    ruff check --fix {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 deps =
     black
-    ruff
     codespell
+    ruff
 commands =
-    # uncomment the following line if this charm owns a lib
-    # codespell {[vars]lib_path}
-    codespell {toxinidir} \
-              --skip {toxinidir}/.git \
-              --skip {toxinidir}/.tox \
-              --skip {toxinidir}/upstream \
-              --skip {toxinidir}/icon.svg
-    
-    ruff {[vars]all_path}
-    black --check --diff {[vars]all_path}
+    codespell {[vars]all_path}
+    black -l 99 --check --diff {[vars]all_path}
+    ruff check {[vars]all_path}
 
 [testenv:unit]
 description = Run unit tests


### PR DESCRIPTION
[LP:2053143](https://bugs.launchpad.net/charm-calico-enterprise/+bug/2053143)

`calico-enterprise` needs quite a bit of configuration before the charm will do anything useful:  license file, registry auth, bgp configuration, cidr ranges, etc.

If any of these are missing on initial deploy, the charm will incorrectly proceed through start->install->config->relation hooks sooner than it should, leading to an invalid state.  This PR addresses that and a few other things:

- lint/license/tox consistent with out other charmed k8s charms
- comment/config/status message tweaks
- ensure the charm lifecycle only proceeds when it has actionable data

Reviewer: the first 3 commits are cosmetic changes to get this charm aligned with other charmed k8s offerings.  The next commit contains the meat of this fix, which is:

- do not let `update-status` proceed if we're not configured
- ensure secret is created before tigera-operator (the latter needs the secret for image pulls)
- ensure tigera-operator is created before the license (the latter needs a tigera-op CRD)

Subsequent bits are to make the integration tests and charm hooks more reliable.